### PR TITLE
Release on merge to main; drop -alpha and tag-based release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ['v*']
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -80,7 +79,7 @@ jobs:
 
   release:
     needs: build-and-test
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: nuget-release
     steps:

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0-alpha",
+  "version": "10.0",
   "publicReleaseRefSpec": [
     "^refs/heads/v\\d+(?:\\.\\d+)?$",
     "^refs/tags/v\\d+\\."

--- a/version.json
+++ b/version.json
@@ -2,8 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "10.0",
   "publicReleaseRefSpec": [
-    "^refs/heads/v\\d+(?:\\.\\d+)?$",
-    "^refs/tags/v\\d+\\."
+    "^refs/heads/main$"
   ],
   "cloudBuild": {
     "buildNumber": {


### PR DESCRIPTION
Two intertwined changes that together enable 'merge to main → automatic stable release':

1. **`version.json`**: drop `-alpha` prerelease label, switch `publicReleaseRefSpec` to `^refs/heads/main$`. Main commits now produce clean `10.0.<height>` stable versions; off-main branches/PRs get `10.0.<height>-g<sha>` (treated as prerelease by the git-sha suffix).
2. **`ci.yml`**: drop the tags trigger; release job now fires on push to main (`if: github.ref == 'refs/heads/main' && github.event_name == 'push'`).

Also removed the now-orphaned `v10.0.0` tag from origin.